### PR TITLE
Process cbz files in chronological order

### DIFF
--- a/cbz-merger.sh
+++ b/cbz-merger.sh
@@ -58,6 +58,10 @@ case $parameter in
     OVERRIDE="yes"
     shift
     ;;
+    --chronological)
+    CHRONOLOGICAL="yes"
+    shift
+    ;;
     -h|--help)
 cat << EOF
 NAME:
@@ -135,7 +139,12 @@ fi
 
 mkdir -p "$TEMP_DIR"
 
-FILES=$(ls -rt "$INPUT"/*$EXTENSION)
+if [ "$CHRONOLOGICAL" ]; then
+    FILES=$(ls -rt "$INPUT"/*$EXTENSION)
+else
+    FILES=$(ls -v "$INPUT"/*$EXTENSION)
+fi
+
 while IFS= read -r FILE; do
     echo Processing `basename "$FILE"`
     unzip -q -d $TEMP_DIR/ "$FILE"

--- a/cbz-merger.sh
+++ b/cbz-merger.sh
@@ -135,7 +135,8 @@ fi
 
 mkdir -p "$TEMP_DIR"
 
-for FILE in "$INPUT"/*$EXTENSION; do
+FILES=$(ls -rt "$INPUT"/*$EXTENSION)
+while IFS= read -r FILE; do
     echo Processing `basename "$FILE"`
     unzip -q -d $TEMP_DIR/ "$FILE"
     for TEMP_FILE in "$TEMP_DIR"/*; do
@@ -143,5 +144,5 @@ for FILE in "$INPUT"/*$EXTENSION; do
     done
     zip -qjur "$OUTPUT_FILE" "$TEMP_DIR"
     rm -rf "$TEMP_DIR"
-done
+done <<< "$FILES"
 echo Done.


### PR DESCRIPTION
I made the processing loop go in chronological order.

I had issues with the processing that mixed up my .cbz files in the wrong order.
e.g. "Vol 10.cbz" would come before "Vol 8.cbz"

```ls -rt``` does that well but because the output of ls is messed up I had to use a while loop.